### PR TITLE
rewrite / add support for incomplete chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ You can start a new connection using `sse-client`, which returns a map containin
 ```clj
 (require '[oxbow.core :as o])
 
-(let [{:keys [abort]} (o/sse-client {:uri "/events"
-                                     :on-event #(js/console.log "Got an event!" %)})]
+(let [abort (o/sse-client {:uri "/events"
+                           :on-event #(js/console.log "Got an event!" %)})]
 
   ;; events are passed to the callback
   ;; call abort to close the client
 
-  (:abort client))
+  (abort))
 ```
 
 ### re-frame

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,1 @@
+{:deps {missionary/missionary {:mvn/version "b.23"}}}

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/oliyh/oxbow"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies []
+  :dependencies [[missionary "b.23"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]
                                        [org.clojure/clojurescript "1.10.764"]
                                        [re-frame "1.1.1"]]}

--- a/src/oxbow/core.cljs
+++ b/src/oxbow/core.cljs
@@ -58,8 +58,7 @@
                     (map :chunk)
                     (sse-chunk-xform)
                     ;; a chunk may contain multiple events
-                    (mapcat #(str/split % #"\n\n"))
-                    (map #(do (js/console.log :chunk %) %))))))
+                    (mapcat #(str/split % #"\n\n"))))))
 
 (def default-opts
   {:on-open  #(js/console.log "Stream connected" %)

--- a/src/oxbow/core.cljs
+++ b/src/oxbow/core.cljs
@@ -1,47 +1,65 @@
 (ns oxbow.core
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [missionary.core :as m]))
 
-(def sse-event-mask (re-pattern "(?s).+?\r\n\r\n"))
+(defn parse-single-event
+  [event data-parser]
+  (reduce (fn [acc kv]
+            (let [[_ k v] (re-find #"(\w*):\s?(.*)" kv)
+                  k (when-not (str/blank? k) (keyword (str/trim k)))]
+              (if k
+                (assoc acc k (when-not (str/blank? v)
+                               (if (= :data k)
+                                 (data-parser v)
+                                 v)))
+                (throw (ex-info "Something is off" {:event event})))))
+          {}
+          (str/split-lines (str/trim event))))
 
-(defn- event-parser [data-parser]
-  (let [buffer (atom "")]
-    (fn [chunk]
-      (let [new-buffer (swap! buffer str chunk)
-            new-events (re-seq sse-event-mask new-buffer)]
+(defn sse-chunk-xform
+  "Returns a transducer that retains incomplete events (i.e. no trailing \n\n)
+  and returns "
+  []
+  (fn [rf]
+    (let [incomplete (volatile! nil)]
+      (fn
+        ([] (rf))
+        ([result] (rf result))
+        ([result el]
+         (cond
+          (and (nil? @incomplete)
+               (.endsWith el "\n\n"))
+          (rf result el)
 
-        ;; clear read events from buffer
-        (swap! buffer str/replace sse-event-mask "")
+          (and @incomplete (.endsWith el "\n\n"))
+          (do (rf result (str @incomplete el))
+              (vreset! incomplete nil))
 
-        (for [event new-events]
-          (try (reduce (fn [acc kv]
-                         (let [[_ k v] (re-find #"(\w*):\s?(.*)" kv)
-                               k (when-not (str/blank? k) (keyword (str/trim k)))]
-                           (if k
-                             (assoc acc k (when-not (str/blank? v)
-                                            (if (= :data k)
-                                              (data-parser v)
-                                              v)))
-                             acc)))
-                       {}
-                       (str/split-lines (str/trim event)))
-               (catch js/Error e
-                 (throw (ex-info "Failed parsing event" {:event event} e)))))))))
+          :else
+          (vswap! incomplete str el)))))))
 
-(defn- read-stream [reader {:keys [on-event on-close on-error data-parser] :as opts}]
-  (let [decoder (js/TextDecoder.)
-        event-parser (event-parser data-parser)]
-    (-> (.read reader)
-        (.then (fn [result]
-                 (if (.-done result)
-                   (when on-close (on-close))
-
-                   (try (doseq [event (event-parser (.decode decoder (.-value result)))]
-                          (on-event event))
-                        (catch js/Error e
-                          (when on-error (on-error e)))
-                        (finally
-                          (read-stream reader opts))))))
-        (.catch on-error))))
+(defn read-chunks
+  "Read from `reader` and parse chunks into SSE events (string form)"
+  [reader]
+  (->> (m/ap
+        (let [decoder (js/TextDecoder.)]
+          (loop []
+            (let [result (m/? (fn [s f] (.then (.read reader) s f) #()))]
+              (if (.-done result)
+                (do (.cancel reader) ; not sure if this works
+                    {:done? (.-done result)})
+                (m/amb>
+                 (let [decoded (.decode decoder (.-value result))]
+                   {:complete? (.endsWith decoded "\n\n")
+                    :chunk decoded})
+                 (recur)))))))
+       (m/eduction (comp
+                    (take-while (comp not :done?))
+                    (map :chunk)
+                    (sse-chunk-xform)
+                    ;; a chunk may contain multiple events
+                    (mapcat #(str/split % #"\n\n"))
+                    (map #(do (js/console.log :chunk %) %))))))
 
 (def default-opts
   {:on-open  #(js/console.log "Stream connected" %)
@@ -52,34 +70,50 @@
    :auto-reconnect? true
    :reconnect-timeout 2000})
 
-(defn sse-client [opts]
+(defn sse-client
+  [opts]
   (let [abort-state (or (::abort-state opts)
                         (let [controller (js/AbortController.)
                               signal (.-signal controller)]
                           (atom {:controller controller
                                  :signal signal
                                  :aborted? false})))
-        {:keys [auto-reconnect? reconnect-timeout uri fetch-options on-open]} (merge default-opts opts)
-        {:keys [on-error on-close] :as opts}
-        (-> opts
-            (update :on-error (fn [on-error]
-                                (fn [e]
-                                  (when (and on-error (not (:aborted? @abort-state)))
-                                    (on-error e)))))
-            (update :on-close (fn [on-close]
-                                (fn []
-                                  (when on-close (on-close))
-                                  (when (and auto-reconnect? (not (:aborted? @abort-state)))
-                                    (js/console.log "Reconnecting to" uri)
-                                    (js/setTimeout sse-client reconnect-timeout (assoc opts ::abort-state abort-state)))))))]
+        {:keys [uri fetch-options on-open on-event on-error on-close data-parser]} (merge default-opts opts)
+        on-error (fn [e]
+                   (when (and on-error (not (:aborted? @abort-state)))
+                     (on-error e)))
+        abort-fetch! #(do (js/console.log "Aborting connection to" uri)
+                          (swap! abort-state assoc :aborted? true)
+                          (.abort (:controller @abort-state)))]
     (-> (js/fetch uri (clj->js (assoc fetch-options :signal (:signal @abort-state))))
         (.then (fn [response]
                  (when on-open (on-open response))
-                 (read-stream (.. response -body getReader) opts)))
+                 ((->> (read-chunks (.. response -body getReader))
+                       (m/eduction (map #(parse-single-event % data-parser)))
+                       (m/reduce #(on-event %2)))
+                  ;; called when the flow above reaches an end (i.e. done)
+                  (fn done
+                    []
+                    (when on-close (on-close)))
+                  ;; called when an error occurs or the flow is cancelled by its consumer
+                  (fn err
+                    [e]
+                    (when on-error (on-error e))
+                    (abort-fetch!)))))
         (.catch (fn [e]
                   (when on-error (on-error e))
-                  (when on-close (on-close)))))
-    {:abort #(do (js/console.log "Aborting connection to" uri)
-                 (swap! abort-state assoc :aborted? true)
-                 (.abort (:controller @abort-state)))
-     :opts opts}))
+                  (when on-close (on-close)))))))
+
+(comment
+ (sequence
+  (comp
+   (sse-chunk-xform)
+   (mapcat #(str/split % #"\n\n")))
+  ["thing 1\n\n"
+   "thing2: "
+   "also thing2\n\n"
+   "thing3\n\nthing4\n\n"])
+
+ ["thing 1\n\n"
+  "thing2: "]
+ )

--- a/src/oxbow/re_frame.cljs
+++ b/src/oxbow/re_frame.cljs
@@ -10,7 +10,7 @@
 (rf/reg-event-fx
  ::abort
  (fn [{:keys [db]} [_ id-or-url]]
-   (when-let [{:keys [abort]} (get-in db [::oxbow :sse-client id-or-url])]
+   (when-let [abort (get-in db [::oxbow :sse-client id-or-url])]
      (merge {:db (update-in db [::oxbow :sse-client] dissoc id-or-url)}
             (when abort
               {::abort abort})))))


### PR DESCRIPTION
When receiving large events from the server the reader will sometimes return incomplete chunks. The previous implementation did not fully account for this and emitted incomplete messages / failed depending on what `data-reader` option was provided.

The addition of `missionary` could probably be avoided but given the stream nature of this I felt like it might be a good idea to use it.

(I realize this PR is incomplete in various ways, most importantly tests haven't been updated.)