### PR TITLE
Fix buffering chunks when they don’t comprise the whole SSE event

### DIFF
--- a/test/oxbow/core_test.cljs
+++ b/test/oxbow/core_test.cljs
@@ -2,9 +2,12 @@
   (:require [oxbow.core :as o]
             [cljs.test :refer-macros [deftest testing is async]]))
 
+(defn- encode-string [s]
+  (.encode (js/TextEncoder.) s))
+
 (deftest event-parser-test
   (testing "can parse a full event in one go"
-    (let [event-parser (@#'o/event-parser identity)]
+    (let [event-parser (comp (@#'o/event-parser identity) encode-string)]
       (is (= [{:event "greeting"
                :data "Hello world"
                :id "abc-def-123"
@@ -15,7 +18,7 @@
                             retry: 123\r\n\r\n")))))
 
   (testing "can parse a full event in multiple chunks"
-    (let [event-parser (@#'o/event-parser identity)]
+    (let [event-parser (comp (@#'o/event-parser identity) encode-string)]
       (is (empty? (event-parser "event: greeting\r\n")))
       (is (empty? (event-parser "data: Hello world\r\n")))
       (is (empty? (event-parser "id: abc-def-123\r\n")))
@@ -26,11 +29,11 @@
              (event-parser "retry: 123\r\n\r\n")))))
 
   (testing "can parse a minimal event"
-    (let [event-parser (@#'o/event-parser identity)]
+    (let [event-parser (comp (@#'o/event-parser identity) encode-string)]
       (is (= [{:data "Hello world"}] (event-parser "data: Hello world\r\n\r\n")))))
 
   (testing "can parse multiple events"
-    (let [event-parser (@#'o/event-parser identity)]
+    (let [event-parser (comp (@#'o/event-parser identity) encode-string)]
       (is (= [{:event "greeting"
                :data "Hello world"
                :id "abc-def-123"
@@ -50,7 +53,7 @@
                             retry: 123\r\n\r\n")))))
 
   (testing "can accept custom event parser"
-    (let [event-parser (@#'o/event-parser #(str "prefix-" %))]
+    (let [event-parser (comp (@#'o/event-parser #(str "prefix-" %)) encode-string)]
       (is (= [{:data "prefix-Hello world"}] (event-parser "data: Hello world\r\n\r\n"))))))
 
 (defn- chunked-reader [chunks]


### PR DESCRIPTION
# About this PR

This PR fixes two closely related bugs in event parsing.

## Bug 1: `read-stream` incorrectly reinitializing event parser every time it’s called

`event-parser` has support for buffering an incompletely-read event chunk, but there was a bug in `read-stream` that rendered this functionality unused (it would recreate the event parser with a new, empty buffer each time it called itself recursively).

Commit 1 adds a test case for this, and commit 2 fixes it.

## Bug 2: buffering can corrupt data if the end of a read chunk falls in the middle of a UTF-8 multibyte codepoint

Admittedly, this one’s harder to encounter (if one just streams ASCII then just the previous fix is all they need), but it occurred to me that it’s still a possibility. I figured I might just as well fix this while I’m at it.

Commit 4 adds a test case for this, and commit 5 fixes it.

The fix turned out to be quite complex, as I had to rework `event-parser`’s buffer to be a byte array instead of a string, with rippling consequences. I’m happy to split this PR into smaller parts if this is seen as too big a change.

# Background

At [Fy!](https://www.iamfy.co/), we’ve recently implemented an [AI rooms designer](https://www.iamfy.co/rooms), which lets you upload a photo of your room, and generates a number of redesigns in various styles. It uses SSE to stream the generated images back to the browser, and on the client side, it uses Oxbow (with its re-frame integration) to parse incoming events.

When the existing results for a room are re-requested, they are streamed back in one event. We noticed that the larger that event is, the bigger its chance to trigger Bug 1. It was discovered by breakpointing the compiled JS bundle and inspecting the chunks processed by Oxbow’s `read-stream`.

Until this PR is merged and a new version of Oxbow released, we plan to either maintain our fork, or monkey-patch it by redefining `read-stream` (essentially applying the second commit; our JSON is ASCII-clean).

Thanks for the great library, by the way!

# How to review & test it

Reviewing: Read each commit in isolation. I’ve tried to make each commit self-contained and the commit messages should explain why the change is being made.

Testing: Just run `lein test` as usual; tests should continue to pass. I added test cases for the bugs and refactored the tests somewhat. This PR has been developed on a Mac, so I had to locally change the path to Chrome in `tests.cljs.edn`, but I didn’t commit that.